### PR TITLE
Fix to cap very large position values

### DIFF
--- a/lib/src/video_player/method_channel_video_player.dart
+++ b/lib/src/video_player/method_channel_video_player.dart
@@ -217,6 +217,11 @@ class MethodChannelVideoPlayer extends VideoPlayerPlatform {
         ) ??
         0;
 
+    // Sometimes the media server returns a absolute position far greater than 
+    // the datetime instance can handle. This caps the value to the maximum the datetime 
+    // can use.
+    if (milliseconds > 8640000000000000 || milliseconds < -8640000000000000) return null;
+
     if (milliseconds <= 0) return null;
 
     return DateTime.fromMillisecondsSinceEpoch(milliseconds);


### PR DESCRIPTION
**Note:** This is a copy of the PR I created for the original player. 

We have seen in some situations when using nimble media server. The position values can come though as what looks like close to max int64 values such as 9223372036850115913

Which causes the following error when flutter tries to convert the value to a using DateTime.fromMillisecondsSinceEpoch().

RangeError (millisecondsSinceEpoch): Invalid value: Not in inclusive range -8640000000000000..8640000000000000: 9223372036850115913

Our guess is this only happens with streams that don't have an end (such as tv).

The below patch checks the value and accordingly returns null if the value for position exceeded what the datetime can handle.

This issue has been raised in the following two reports:

https://github.com/jhomlala/betterplayer/issues/1068
https://github.com/jhomlala/betterplayer/issues/884