### PR TITLE
Add enableReplay property in controls configuration (Android Only Opt…

### DIFF
--- a/lib/src/configuration/better_player_controls_configuration.dart
+++ b/lib/src/configuration/better_player_controls_configuration.dart
@@ -161,6 +161,9 @@ class BetterPlayerControlsConfiguration {
   ///Color of text in bottom modal sheet used for overflow menu items.
   final Color overflowModalTextColor;
 
+  ///Enable middle replay button - Android only option.
+  final bool enableReplay;
+
   const BetterPlayerControlsConfiguration({
     this.controlBarColor = Colors.black87,
     this.textColor = Colors.white,
@@ -213,6 +216,7 @@ class BetterPlayerControlsConfiguration {
     this.backgroundColor = Colors.black,
     this.overflowModalColor = Colors.white,
     this.overflowModalTextColor = Colors.black,
+    this.enableReplay = true,
   });
 
   factory BetterPlayerControlsConfiguration.white() {

--- a/lib/src/controls/better_player_material_controls.dart
+++ b/lib/src/controls/better_player_material_controls.dart
@@ -387,7 +387,10 @@ class _BetterPlayerMaterialControlsState
                   Expanded(child: _buildSkipButton())
                 else
                   const SizedBox(),
-                Expanded(child: _buildReplayButton(_controller!)),
+                if (_controlsConfiguration.enableReplay)
+                  Expanded(child: _buildReplayButton(_controller!))
+                else
+                  const SizedBox(),
                 if (_controlsConfiguration.enableSkips)
                   Expanded(child: _buildForwardButton())
                 else


### PR DESCRIPTION
Currently, there is no property to disable the middle native replay button of the Android controls. This is annoying for cases when the library user built his own controls UI (since he will have duplicated play/replay buttons, his and the one of the Material Controls from the middle of the screen). This change is backwards compatible.