### PR TITLE
add getter to check if the controller is disposed.

### DIFF
--- a/lib/src/core/better_player_controller.dart
+++ b/lib/src/core/better_player_controller.dart
@@ -125,6 +125,8 @@ class BetterPlayerController {
   ///Has player been disposed.
   bool _disposed = false;
 
+  bool get disposed => _disposed;
+
   ///Was player playing before automatic pause.
   bool? _wasPlayingBeforePause;
 


### PR DESCRIPTION
If we are overriding onVisibility changed manually, say I wanted to check if controller is already disposed before calling any methods on controller then this getter should help.